### PR TITLE
Use const T

### DIFF
--- a/include/cpptracer/trace.hpp
+++ b/include/cpptracer/trace.hpp
@@ -66,7 +66,7 @@ template <typename T>
 class TraceWrapper : public Trace {
 public:
     /// A pointer to the variable that has to be traced.
-    T *ptr;
+    const T *ptr;
     /// Previous value of the trace.
     T previous;
 
@@ -74,7 +74,7 @@ public:
     /// @param _name     The name of the trace.
     /// @param _symbol   The symbol to assign.
     /// @param _ptr      Pointer to the variable.
-    TraceWrapper(std::string _name, std::string _symbol, T *_ptr)
+    TraceWrapper(std::string _name, std::string _symbol, const T *_ptr)
         : Trace(_name, _symbol),
           ptr(_ptr),
           previous(),
@@ -284,8 +284,8 @@ inline bool TraceWrapper<long double>::hasChanged()
 template <>
 inline bool TraceWrapper<std::vector<bool>>::hasChanged()
 {
-    auto it_prev = previous.begin(), it_curr = ptr->begin();
-    while ((it_prev != previous.end()) && (it_curr != ptr->end())) {
+    auto it_prev = previous.cbegin(), it_curr = ptr->cbegin();
+    while ((it_prev != previous.cend()) && (it_curr != ptr->cend())) {
         if ((*it_curr) != (*it_prev))
             return true;
         ++it_prev, ++it_curr;

--- a/include/cpptracer/tracer.hpp
+++ b/include/cpptracer/tracer.hpp
@@ -168,10 +168,10 @@ public:
     /// @param name     The name of the trace.
     /// @param variable The variable which has to be traced.
     template <typename T>
-    void addTrace(T &variable, const std::string &name)
+    void addTrace(const T &variable, const std::string &name)
     {
         assert(current_scope && "There is no current scope.");
-        current_scope->traces.push_back(new TraceWrapper<T>(name, utility::get_unique_name(3), &variable));
+        current_scope->traces.push_back(new TraceWrapper(name, utility::get_unique_name(3), &variable));
     }
 
     /// @brief Updates the trace file with the current variable values.


### PR DESCRIPTION
Without this PR type `T` for constant variables will be deduced as `const T` and you won't be able to compile it because it will think that `previous` is `const`:
https://github.com/Galfurian/cpptracer/blob/88d7ef37e8d9571e3acc5a8d86b86faf60a8ba26/include/cpptracer/trace.hpp#L102