### PR TITLE
Additional minor fixes

### DIFF
--- a/include/cpptracer/tracer.hpp
+++ b/include/cpptracer/tracer.hpp
@@ -304,7 +304,7 @@ private:
     template <typename T>
     inline T getScaledTime(long double const &t) const
     {
-        return static_cast<T>(t / timescale.getTimeUnit().toValue());
+        return static_cast<T>(std::round(t / timescale.getTimeUnit().toValue()));
     }
 
     /// @brief Issue each trace to save the current value as `previous value`.

--- a/include/cpptracer/utilities.hpp
+++ b/include/cpptracer/utilities.hpp
@@ -48,7 +48,7 @@ const std::string dec_to_binary(T value)
 /// @brief Transforms the given vector of booleans to a binary string.
 /// @param vec the vector to transform.
 /// @return the string representing the vector of booleans.
-const std::string vec_to_binary(const std::vector<bool> &vec)
+inline const std::string vec_to_binary(const std::vector<bool> &vec)
 {
     std::string buffer(vec.size(), '0');
     for (unsigned i = 0; i < vec.size(); ++i)


### PR DESCRIPTION
* Add missing inline. Without it the function breaks ODR.
* Use `std::round` to calculate scaled time. Otherwise you may lose perception. I sometimes getting duplicated indexes
in my project when we use NS without this change.